### PR TITLE
chore: update to track official SDK 1.0.0-RC3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src"]
  :deps  {com.cnuernber/charred     {:mvn/version "1.037"}
-         dev.data-star.clojure/sdk {:mvn/version "1.0.0-RC1"}
+         dev.data-star.clojure/sdk {:mvn/version "1.0.0-RC3"}
          dev.onionpancakes/chassis {:mvn/version "1.0.365"}
          no.cjohansen/nexus        {:mvn/version "2025.07.1"}}
  :aliases
  {:dev {:extra-paths ["dev/src"]
-        :extra-deps  {dev.data-star.clojure/brotli   {:mvn/version "1.0.0-RC1"}
-                      dev.data-star.clojure/http-kit {:mvn/version "1.0.0-RC1"}
-                      dev.data-star.clojure/ring     {:mvn/version "1.0.0-RC1"}
+        :extra-deps  {dev.data-star.clojure/brotli   {:mvn/version "1.0.0-RC3"}
+                      dev.data-star.clojure/http-kit {:mvn/version "1.0.0-RC3"}
+                      dev.data-star.clojure/ring     {:mvn/version "1.0.0-RC3"}
                       hiccup/hiccup                  {:mvn/version "2.0.0"}
                       integrant/integrant            {:mvn/version "0.13.1"}
                       io.github.tonsky/clj-reload    {:mvn/version "0.9.7"}
@@ -25,7 +25,7 @@
           slipset/deps-deploy {:mvn/version "0.2.2"}}
          :ns-default slim.lib
          :exec-args {:lib         com.github.brianium/datastar.wow
-                     :version     "1.0.0-RC1-wow2"
+                     :version     "1.0.0-RC3-wow0"
                      :url         "https://github.com/brianium/datastar.wow"
                      :description "Decalarative and data-oriented Datastar apps for Clojure"
                      :developer   "Brian Scaturro"}}}}

--- a/dev/src/demo/app.clj
+++ b/dev/src/demo/app.clj
@@ -23,6 +23,7 @@
   [{:keys [type]
     :or {type :httpkit}
     :as deps}]
+  (println "creating with-datastar middleware:" (pr-str deps))
   (d*/with-datastar (case type
                       :httpkit  hk/->sse-response
                       :httpkit2 hk2/->sse-response
@@ -49,6 +50,7 @@
   [{:keys [type]
     :or {type :httpkit}
     :as deps}]
+  (println "creating server:" (pr-str deps))
   (case type
     :httpkit (demo.server/httpkit-server (dissoc deps :type))
     :jetty   (demo.server/jetty-server (dissoc deps :type))))

--- a/dev/src/demo/config.clj
+++ b/dev/src/demo/config.clj
@@ -1,6 +1,9 @@
 (ns demo.config
-  (:require [demo.app :as app]
-            [integrant.core :as ig]))
+  (:require [datastar.wow :as d*]
+            [demo.app :as app]
+            [integrant.core :as ig]
+            [starfederation.datastar.clojure.adapter.http-kit2 :refer [start-responding-middleware]]
+            [starfederation.datastar.clojure.brotli :as brotli]))
 
 (defmethod ig/init-key ::constant [_ x] x)
 (derive ::initial-state ::constant)
@@ -8,13 +11,26 @@
 (defmethod ig/halt-key! ::app/server [_ stop-fn]
   (stop-fn))
 
+(def adapter
+  "Change this to :jetty, :httpkit, or :httpkit2 then call (clj-reload.core/reload).
+   Useful for testing with different adapters"
+  :httpkit)
+
+(def write-profile
+  "Set this to nil if you want to test without a write profile"
+  (brotli/->brotli-profile))
+
 (def config
-  {::app/with-datastar {:type :httpkit}
+  {::app/with-datastar (cond-> {:type adapter}
+                         (some? write-profile) (assoc ::d*/write-profile write-profile))
    ::app/router        {:routes     app/routes
                         :middleware [(ig/ref ::app/with-datastar)]}
    ::app/handler       {:router     (ig/ref ::app/router)
-                        ;;; include starfederation.datastar.clojure.adapter.http-kit2/start-responding-middleware if using http-kit2 adapter
-                        :middleware []} 
+                        :middleware (cond-> []
+                                      (= adapter :httpkit2) (conj start-responding-middleware))}
    ::app/server        {:handler (ig/ref ::app/handler)
-                        :type :httpkit}
+                        :type (condp = adapter
+                                :httpkit  adapter
+                                :httpkit2 :httpkit
+                                :jetty    adapter)}
    ::app/state         app/initial-state})


### PR DESCRIPTION
Pushing a new version to track with 1.0.0-RC3.

Also changed the demo.config namespace to be a little easier to swap out adapters, servers, and write profiles.