### PR TITLE
Replace update-nexus option with registry option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Change Log
+
+## [1.0.0-RC3-wow1] - 2025-09-20
+
+### Breaking Changes
+
+Removed `:datastar.wow/update-nexus` and replaced it with `:datastar.wow/registries`. `:datastar.wow/update-nexus` will now be ignored.
+
+### Changed
+
+Effect + Nexus extension is now powered by registries. A registry IS a Nexus map, but with `:datastar.wow` namespaced keys. Keys are aliased
+not to aura farm, but to reduce cognitive load (single require is a good thing).
+
+```clojure
+(def effect-map
+  {::d*/effects
+    {::myeffect
+      (fn [ctx system arg1]
+        (println arg1))}})
+
+(defn effect-map-fn []
+  {::d*/effects
+    {::myeffect
+      (fn [ctx system arg1]
+        (println arg1))}})
+
+(defn effect-map-fn-1
+  [arg1]
+  {::d*/effects
+    {::othereffect
+      (fn [ctx system]
+        (println arg1))}})
+
+;;; No more ::d*/update-nexus
+(d*/with-datastar ->sse-response {::d*/registries [effect-map effect-map-fn [effect-map-fn-1 "Mama mia!"]]})
+```
+
+The vector syntax is particularly useful for scenarios using a component system like [integrant](https://github.com/weavejester/integrant).
+
+``` clojure
+(require '[integrant.core :as ig])
+
+(def config
+  {::datastar-config
+    {::d*/registries [effect-map effect-fn [sql-effect (ig/ref ::database-fn)]]}})
+```
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
-Removed `:datastar.wow/update-nexus` and replaced it with `:datastar.wow/registries`. `:datastar.wow/update-nexus` will now be ignored.
+Removed `:datastar.wow/update-nexus` and replaced it with `:datastar.wow/registries`. `:datastar.wow/update-nexus` will now be ignored. Adds `dispatch`
+function for creating a dispatch function for "out of band" dispatches.
 
 ### Changed
 
@@ -45,3 +46,15 @@ The vector syntax is particularly useful for scenarios using a component system 
     {::d*/registries [effect-map effect-fn [sql-effect (ig/ref ::database-fn)]]}})
 ```
 
+### Added
+
+Adds a `dispatch` function that takes a subset of `with-datstar` options: `::d*/registries`, `::d*/write-json`, and `::d*/write-html`. This
+dispatch can be passed to `with-datastar`.
+
+```clojure
+(def my-dispatch (d*/dispatch {::d*/registries [my-app-effects]}))
+
+(d*/with-datastar ->sse-response {::d*/dispatch my-dispatch})
+```
+
+If a dispatch function is given, `::d*/registries`, `::d*/write-json`, and `::d*/write-html` options given to `with-datastar` will be ignored.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A more declarative and data-oriented way to build [Datastar](https://data-star.d
 - [Extending](#extending)
 - [Demo](#demo)
 - [Html Supremacy](#html-supremacy)
+- [CHANGELOG](CHANGELOG.md)
 
 ## Quick Example
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A more declarative and data-oriented way to build [Datastar](https://data-star.d
 - [Options](#with-datastar-options)
 - [Responses](#responses)
 - [Extending](#extending)
+- [Dispatch](#dispatch)
 - [Demo](#demo)
 - [Html Supremacy](#html-supremacy)
 - [CHANGELOG](CHANGELOG.md)
@@ -163,6 +164,7 @@ The second argument to `with-datastar` is an options map that can be used to cus
 | `::d*/with-open-sse?` | If true, all SSE responses will be wrapped in `d*/with-open-sse`. Defaults to false. Can be configured per response                               |
 | `::d*/write-profile`  | Applies a `:d*.sse/write-profile` to all SSE responses. Defaults to the SDK default. Can be configured per response                               |
 | `::d*/registries  `   | A vector of effect registries. An effect registry is an effect map, a function returning an effect map, or a vector (see [extending](#extending)) |
+| `::d*/dispatch`       | An existing dispatch function. If present, `::d*/registries`, `d*::write-html`, and `::d*/write-json` will be ignored. See [dispatch](#dispatch)  |
 | `::d*/write-html`     | The html serialization function used for :body and events. Defaults to dev.onionpancakes.chassis.core/html (recommended)                          |
 | `::d*/read-json`      | The json function used to deserialize datastar signals. Defaults to a custom parse-fn powered by charred.api/parse-json-fn                        |
 | `::d*/write-json`     | The json function used to serialize Clojure structures to json strings. Defaults to charred.api/write-json-str                                    |
@@ -333,6 +335,52 @@ The following keys will exist on Nexus dispatch data by default:
 | `::d*/response`       | The response returned by the handler.                               |
 | `::d*/request`        | The ring request used to initiate the connection                    |
 | `::d*/with-open-sse?` | Whether or not the connection is set to close after events are sent |
+
+## Dispatch
+
+The `datastar.wow/dispatch` function can be used to create a dispatch function supporting all datastar.wow effects. It takes a subset of arguments that `with-datastar` takes:
+
+| key                   | description                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `::d*/registries  `   | A vector of effect registries. An effect registry is an effect map, a function returning an effect map, or a vector (see [extending](#extending)) |
+| `::d*/write-html`     | The html serialization function used for :body and events. Defaults to dev.onionpancakes.chassis.core/html (recommended)                          |
+| `::d*/write-json`     | The json function used to serialize Clojure structures to json strings. Defaults to charred.api/write-json-str                                    |
+
+This is useful for creating a dispatch function that can be used "out of band" (i.e dispatch not bound to a particular sse connection or ring request). The returned function
+will have the following signature.
+
+```clojure
+(fn dispatch
+  ([dispatch-data fx])
+  ([system dispatch-data fx]))
+```
+
+If dispatching effects reliant on an sse connection, make sure the `system` map has an `:sse` connection and a ring `:request`.
+
+``` clojure
+(dispatch {:sse some-conn :request ring-request} dispatch-data [[::effect arg1 arg2]])
+```
+
+`with-datastar` generally provides the following dispatch data:
+
+``` clojure
+{::d*/response       ring-response
+ ::d*/request        ring-request
+ ::d*/with-open-sse? bool}
+```
+
+Be aware that userland interceptors and effects may rely on those values being present.
+
+### Use an existing dispatch function in with-datastar
+
+A dispatch function created by `datastar.wow/dispatch` can be given to `with-datastar`. If present, `:datastar.wow/registries`, `:datastar.wow/write-html` and `:datastar.wow/write-json` options
+will be ignored.
+
+``` clojure
+(def dispatch (d*/dispatch {::d*/registries [myappregistry]}))
+
+(def with-datastar (d*/with-datastar ->sse-response {::d*/dispatch dispatch}))
+```
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -157,15 +157,15 @@ The connection used by dispatch will use the following priority order:
 
 The second argument to `with-datastar` is an options map that can be used to customize and configure.
 
-| key                   | description                                                                                                                |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `::d*/with-open-sse?` | If true, all SSE responses will be wrapped in `d*/with-open-sse`. Defaults to false. Can be configured per response        |
-| `::d*/write-profile`  | Applies a `:d*.sse/write-profile` to all SSE responses. Defaults to the SDK default. Can be configured per response        |
-| `::d*/update-nexus`   | A function that takes the default nexus config and returns a new one. See [nexus docs](https://github.com/cjohansen/nexus) |
-| `::d*/write-html`     | The html serialization function used for :body and events. Defaults to dev.onionpancakes.chassis.core/html (recommended)   |
-| `::d*/read-json`      | The json function used to deserialize datastar signals. Defaults to a custom parse-fn powered by charred.api/parse-json-fn |
-| `::d*/write-json`     | The json function used to serialize Clojure structures to json strings. Defaults to charred.api/write-json-str             |
-| `::d*/html-attrs`     | A map of html attributes that will be provided to any hiccup forms used in the :body key of any response                   |
+| key                   | description                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `::d*/with-open-sse?` | If true, all SSE responses will be wrapped in `d*/with-open-sse`. Defaults to false. Can be configured per response                               |
+| `::d*/write-profile`  | Applies a `:d*.sse/write-profile` to all SSE responses. Defaults to the SDK default. Can be configured per response                               |
+| `::d*/registries  `   | A vector of effect registries. An effect registry is an effect map, a function returning an effect map, or a vector (see [extending](#extending)) |
+| `::d*/write-html`     | The html serialization function used for :body and events. Defaults to dev.onionpancakes.chassis.core/html (recommended)                          |
+| `::d*/read-json`      | The json function used to deserialize datastar signals. Defaults to a custom parse-fn powered by charred.api/parse-json-fn                        |
+| `::d*/write-json`     | The json function used to serialize Clojure structures to json strings. Defaults to charred.api/write-json-str                                    |
+| `::d*/html-attrs`     | A map of html attributes that will be provided to any hiccup forms used in the :body key of any response                                          |
 
 Not that `::d*/with-open-sse?` and `::d*/write-profile` keys can be provided on a per response basis.
 
@@ -184,7 +184,42 @@ The response map returned by a ring handler supports a few extra keys to tailor 
 
 ## Extending
 
-The extension point for `datastar.wow` is via the `::d*/update-nexus` option. It opens a world of possibilities for things like logging, observability, error capture, connection storage, domain specific effects/actions, placeholders, etc. The [Nexus docs](https://github.com/cjohansen/nexus) are very good, and should give a good tour of what is possible.
+The extension point for `datastar.wow` is via the `::d*/registries` option. It opens a world of possibilities for things like logging, observability, error capture, connection storage, domain specific effects/actions, placeholders, etc. The [Nexus docs](https://github.com/cjohansen/nexus) are very good, and should give a good tour of what is possible.
+
+A registry is an effect map, a zero arity function that returns an effect map or a vector containing a function and any args it will be invoked with. This function should return an effect map.
+
+```clojure
+(def effect-map
+  {::d*/effects
+    {::myeffect
+      (fn [ctx system arg1]
+        (println arg1))}})
+
+(defn effect-map-fn []
+  {::d*/effects
+    {::myeffect
+      (fn [ctx system arg1]
+        (println arg1))}})
+
+(defn effect-map-fn-1
+  [arg1]
+  {::d*/effects
+    {::othereffect
+      (fn [ctx system]
+        (println arg1))}})
+
+(d*/with-datastar ->sse-response {::d*/registries [effect-map effect-map-fn [effect-map-fn-1 \"Mama mia!\"]]})
+```
+
+The vector syntax is particularly useful for scenarios using a component system like [integrant](https://github.com/weavejester/integrant).
+
+``` clojure
+(require '[integrant.core :as ig])
+
+(def config
+  {::datastar-config
+    {::d*/registries [effect-map effect-fn [sql-effect (ig/ref ::database-fn)]]}})
+```
 
 ### Example: Pure actions with access to signals as state
 
@@ -199,10 +234,11 @@ State in a Datastar application is signals. Any action added to the `datastar.wo
      (fn [m k v]
        (assoc m k (string/upper-case v))) {} signals)]])
 	   
-(defn update-nexus
-  "We can provide this as the ::d*/update-nexus option to with-datastar"
-  [nexus]
-  (assoc-in nexus [:nexus/actions ::uc-signals] uc-signals))
+(def registry
+  {::d*/actions
+    {::uc-signals uc-signals}})
+	
+(d*/with-datastar ->sse-response {::d*/registries [registry]})
 ``` 
 
 ### Example: Using placeholders for asynchronous effects
@@ -228,11 +264,12 @@ Sometimes we don't have data available to us when we first describe our set of e
                            :on-complete [::fx/merge-metadata agent {:jobs {job-key nil}}]
                            :on-start    [::fx/merge-metadata agent {:jobs {job-key job}}]
                            :on-partial  [::fx/save-image agent entry-id [::fx.placeholders/partial-image]]}]]} ;;; Datastar! Wow!
-						   
-(defn update-nexus
-  "We can provide this as the ::d*/update-nexus option to with-datastar"
-  [nexus]
-  (update nexus :nexus/placeholders merge {::fx.placeholders/partial-image partial-image}))
+
+(def registry
+  {::d*/placeholders
+    {::partial-image partial-image}})
+	
+(d*/with-datastar ->sse-response {::d*/registries [registry]})
 ```
 
 ### Example: Persisting connections via interceptor
@@ -250,37 +287,35 @@ dispatch data, and so we use that fact to create a unique id from the session an
   Storage is cleared in response to an sse-closed event. *abort-chs is an atom for storing abort channels persistent across dispatches
   Note: This app supports an optional ::abort-ch key on any response. If provided, it will be signaled during close"
   [store *abort-chs]
-  {:id ::manage-connections
-   :before-dispatch
-   (fn [{:keys [system dispatch-data] :as ctx}]
-     (let [{:keys [request sse]} system
-           store? (not (::d*/with-open-sse? dispatch-data))
-           session-id (get-in request [:session :session-id])
-           conn-id    (get-in dispatch-data [::d*/response ::conn-id])] ;;; the ring handler response is available as dispatch data
-       (when (and store? session-id conn-id (some? sse)) ;;; sse will be nil on close effects
-         (conns/store! store [session-id conn-id] sse)))
-     ctx)
-   :before-effect ;;; aggregate abort channels
-   (fn [{:keys [dispatch-data] :as ctx}]
-     (let [{{::keys [abort-ch]} ::d*/response} dispatch-data]
-       (when (some? abort-ch)
-         (swap! *abort-chs conj abort-ch))
-       ctx))
-   :after-effect
-   (fn [{:keys [effect system dispatch-data] :as ctx}]
-     (let [{{{:keys [session-id]} :session} :request} system]
-       (when (and effect (= ::d*/sse-closed (first effect)))
-         (doseq [abort-ch @*abort-chs]
-           (swap! *abort-chs disj abort-ch)
-           (async/put! abort-ch ::yeet))
-         (when-some [conn-id (get-in dispatch-data [::d*/response ::conn-id])]
-           (conns/purge! store [session-id conn-id]))))
-     ctx)})
-	 
-(defn update-nexus
-  "We can provide this as the ::d*/update-nexus option to with-datastar"
-  [nexus]
-  (assoc nexus :nexus/interceptors (manage-connections (conn-store) (atom #{}))))
+  {::d*/interceptors
+   [{:id ::manage-connections
+     :before-dispatch
+     (fn [{:keys [system dispatch-data] :as ctx}]
+       (let [{:keys [request sse]} system
+             store? (not (::d*/with-open-sse? dispatch-data))
+             session-id (get-in request [:session :session-id])
+             conn-id    (get-in dispatch-data [::d*/response ::conn-id])] ;;; the ring handler response is available as dispatch data
+         (when (and store? session-id conn-id (some? sse)) ;;; sse will be nil on close effects
+           (conns/store! store [session-id conn-id] sse)))
+       ctx)
+     :before-effect ;;; aggregate abort channels
+     (fn [{:keys [dispatch-data] :as ctx}]
+       (let [{{::keys [abort-ch]} ::d*/response} dispatch-data]
+         (when (some? abort-ch)
+           (swap! *abort-chs conj abort-ch))
+         ctx))
+     :after-effect
+     (fn [{:keys [effect system dispatch-data] :as ctx}]
+       (let [{{{:keys [session-id]} :session} :request} system]
+         (when (and effect (= ::d*/sse-closed (first effect)))
+           (doseq [abort-ch @*abort-chs]
+             (swap! *abort-chs disj abort-ch)
+             (async/put! abort-ch ::yeet))
+           (when-some [conn-id (get-in dispatch-data [::d*/response ::conn-id])]
+             (conns/purge! store [session-id conn-id]))))
+       ctx)}]})
+	   
+(d*/with-datastar ->sse-response {::d*/registries [[manage-connections (ig/ref ::store) (ig/ref ::abort-chs)]]})
 ```
 
 The Nexus "system" will have the following keys:

--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
           slipset/deps-deploy {:mvn/version "0.2.2"}}
          :ns-default slim.lib
          :exec-args {:lib         com.github.brianium/datastar.wow
-                     :version     "1.0.0-RC3-wow0"
+                     :version     "1.0.0-RC3-wow1"
                      :url         "https://github.com/brianium/datastar.wow"
                      :description "Decalarative and data-oriented Datastar apps for Clojure"
                      :developer   "Brian Scaturro"}}}}

--- a/src/datastar/wow.clj
+++ b/src/datastar/wow.clj
@@ -14,15 +14,15 @@
 
    Options:
 
-   | key                | description                                                                                                                |
-   | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-   | `::with-open-sse?` | If true, all SSE responses will be wrapped in `d*/with-open-sse`. Defaults to false. Can be configured per response        |
-   | `::write-profile`  | Applies a `:d*.sse/write-profile` to all SSE responses. Defaults to the SDK default. Can be configured per response        |
-   | `::update-nexus`   | A function that takes the default nexus config and returns a new one. See [nexus docs](https://github.com/cjohansen/nexus) |
-   | `::write-html`     | The html serialization function used for :body and events. Defaults to dev.onionpancakes.chassis.core/html (recommended)   |
-   | `::read-json`      | The json function used to deserialize datastar signals. Defaults to a custom parse-fn powered by charred.api/parse-json-fn |
-   | `::write-json`     | The json function used to serialize Clojure structures to json strings. Defaults to charred.api/write-json-str             |
-   | `::html-attrs`     | A map of html attributes that will be provided to any hiccup forms used in the :body key of any response                   |
+   | key                | description                                                                                                                     |
+   | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+   | `::with-open-sse?` | If true, all SSE responses will be wrapped in `d*/with-open-sse`. Defaults to false. Can be configured per response             |
+   | `::write-profile`  | Applies a `:d*.sse/write-profile` to all SSE responses. Defaults to the SDK default. Can be configured per response             |
+   | `::registries`     | A vector of effect registries. An effect registry is an effect map, a function returning an effect map, or a vector (see below) |
+   | `::write-html`     | The html serialization function used for :body and events. Defaults to dev.onionpancakes.chassis.core/html (recommended)        |
+   | `::read-json`      | The json function used to deserialize datastar signals. Defaults to a custom parse-fn powered by charred.api/parse-json-fn      |
+   | `::write-json`     | The json function used to serialize Clojure structures to json strings. Defaults to charred.api/write-json-str                  |
+   | `::html-attrs`     | A map of html attributes that will be provided to any hiccup forms used in the :body key of any response                        |
 
   Example ring responses for handlers using with-datastar:
   ```clojure
@@ -37,9 +37,34 @@
   {:🚀 [[::d*/patch-elements [:h1#demo \"Hello\"] {::d*/patch-mode ::d*/pm-replace}]]} ; enhance fun with the rocket emoji alias
   ```
 
-  The `::update-nexus` option supports extension via [interceptors](https://github.com/cjohansen/nexus?tab=readme-ov-file#interceptors) for things
-  like connection storage and observability. Application specific effects, actions, and placeholders can be provided as well. The \"system\" given
-  to nexus.core/dispatch will contain the following keys:
+  The `::registries` option is used to extend a datastar.wow app. Application specific effects, actions, placeholders, and interceptors can be added.
+  See the [nexus](https://github.com/cjohansen/nexus) documentation for more information. A registry is an effect map, a zero arity function that returns an effect map
+  or a vector containing a function and any args it will be invoked with. This function should return an effect map.
+
+  ```clojure
+  (def effect-map
+    {::d*/effects
+      {::myeffect
+        (fn [ctx system arg1]
+          (println arg1))}})
+
+  (defn effect-map-fn []
+    {::d*/effects
+      {::myeffect
+        (fn [ctx system arg1]
+          (println arg1))}})
+
+  (defn effect-map-fn-1
+    [arg1]
+    {::d*/effects
+      {::othereffect
+        (fn [ctx system]
+          (println arg1))}})
+
+  (d*/with-datastar ->sse-response {::d*/registries [effect-map effect-map-fn [effect-map-fn-1 \"Mama mia!\"]]})
+  ```
+
+  The \"system\" given to nexus.core/dispatch will contain the following keys:
 
   | key        | description                                       |
   | ---------- | ------------------------------------------------- |

--- a/src/datastar/wow.clj
+++ b/src/datastar/wow.clj
@@ -19,6 +19,7 @@
    | `::with-open-sse?` | If true, all SSE responses will be wrapped in `d*/with-open-sse`. Defaults to false. Can be configured per response             |
    | `::write-profile`  | Applies a `:d*.sse/write-profile` to all SSE responses. Defaults to the SDK default. Can be configured per response             |
    | `::registries`     | A vector of effect registries. An effect registry is an effect map, a function returning an effect map, or a vector (see below) |
+   | `::dispatch`       | An existing dispatch function. If present, `::registries`, `::write-html`, and `::write-json` will be ignored. See [[dispatch]] |
    | `::write-html`     | The html serialization function used for :body and events. Defaults to dev.onionpancakes.chassis.core/html (recommended)        |
    | `::read-json`      | The json function used to deserialize datastar signals. Defaults to a custom parse-fn powered by charred.api/parse-json-fn      |
    | `::write-json`     | The json function used to serialize Clojure structures to json strings. Defaults to charred.api/write-json-str                  |
@@ -85,6 +86,21 @@
    (mw/with-datastar ->sse-response {}))
   ([->sse-response & opts]
    (mw/with-datastar ->sse-response opts)))
+
+(defn dispatch
+  "Create a dispatch function. Useful for \"out of band\" dispatch or creating the middleware dispatch ahead of time.
+   The returned dispatch function has the following signature:
+
+  ```clojure
+  (fn dispatch
+    ([dispatch-data fx])
+    ([system dispatch-data fx]))
+  ```
+
+  Please note that dispatching datastar.wow's bundled effects/actions requires system to be a map containing an `:sse` key and a `:request` key
+  with an instance of SSEGen and a ring request respectively."
+  [opts]
+  (mw/create-dispatch opts))
 
 ;;; Official SDK constants re-exported here for convenience
 

--- a/src/datastar/wow/middleware.clj
+++ b/src/datastar/wow/middleware.clj
@@ -43,14 +43,14 @@
    via charred and chassis respectively"
   (create-send json/write-json-str c/html))
 
-(def ^:private default-nexus
+(def ^:private default-registry
   "Default effect configuration. All datastar events are described
    as effects and system state is whatever signals can be read from the request"
-  {:nexus/system->state
+  {:datastar.wow/system->state
    (fn [{:keys [request]}]
-     (request :signals))
+     (:signals request))
 
-   :nexus/effects
+   :datastar.wow/effects
    {:datastar.wow/connection
     (fn [{{:datastar.wow/keys [connection]} :dispatch-data} _]
       connection)
@@ -61,7 +61,7 @@
     :datastar.wow/send ;;; Route through a single :datastar.wow/send action so we can audit all sends
     default-send}
 
-   :nexus/actions
+   :datastar.wow/actions
    {:datastar.wow/patch-elements
     (fn [_ elements & [?opts]]
       [[:datastar.wow/send :datastar.wow/patch-elements elements ?opts]])
@@ -75,61 +75,90 @@
     (fn [_ script-content & [?opts]]
       [[:datastar.wow/send :datastar.wow/execute-script script-content ?opts]])}})
 
-(def fun-enhancers
-  "If we aren't having fun, then what is the point?"
-  {:🚀 :datastar.wow/fx})
-
 (defn- get-connection
   "The connection used by dispatch. Order of priority is:
    - 1. A :datastar.wow/connection key on the response map returned by a handler
    - 2. A :datastar.wow/connection key found in nexus dispatch-data
    - 3. A new sse-gen created in sse-response"
-  [nexus request dispatch-data]
+  [dispatch request dispatch-data]
   (if-some [connection (get-in dispatch-data [:datastar.wow/response :datastar.wow/connection])]
     connection
-    (let [dispatch-result (nexus/dispatch nexus {:sse nil :request request} dispatch-data [[:datastar.wow/connection]])]
+    (let [dispatch-result (dispatch {:sse nil :request request} dispatch-data [[:datastar.wow/connection]])]
       (some->
        dispatch-result
        (:results)
        (first)
        (:res)))))
 
+(def ^:private nexus-aliases
+  {:datastar.wow/system->state :nexus/system->state
+   :datastar.wow/effects :nexus/effects
+   :datastar.wow/placeholders :nexus/placeholders
+   :datastar.wow/actions :nexus/actions
+   :datastar.wow/interceptors :nexus/interceptors})
+
+(defn- merge-registry
+  [acc m]
+  (reduce-kv
+   (fn [r k v]
+     (if-some [nk (nexus-aliases k)]
+       (update r nk (condp = nk
+                      :nexus/interceptors (fnil into [])
+                      :nexus/system->state (constantly v)
+                      merge) v)
+       r)) acc m))
+
+(defn- create-registry
+  "Create a nexus registry for all effects, actions, placeholders, and interceptors. Supports
+   overriding json and html serialization"
+  [registry-specs {:datastar.wow/keys [write-json write-html]}]
+  (let [nexus (reduce (fn [registry spec]
+                        (let [r (cond
+                                  (map? spec)    spec
+                                  (fn? spec)     (spec)
+                                  (vector? spec) (apply (first spec) (rest spec))
+                                  :else {})]
+                          (merge-registry registry r)))
+                      {} registry-specs)]
+    (cond-> nexus
+      (every? some? [write-json write-html])
+      (assoc-in [:nexus/effects :datastar.wow/send] (create-send write-json write-html))
+
+      (some? write-json)
+      (assoc-in [:nexus/effects :datastar.wow/send] (create-send write-json c/html))
+
+      (some? write-html)
+      (assoc-in [:nexus/effects :datastar.wow/send] (create-send json/write-json-str write-html)))))
+
 (defn- sse-response
   [request response opts ->sse-response]
-  (let [{:datastar.wow/keys [with-open-sse? update-nexus write-json write-html write-profile]} opts
+  (let [{:datastar.wow/keys [with-open-sse? dispatch write-profile]} opts
         actions (:datastar.wow/fx response)
-        nex     (cond-> default-nexus
-                  (every? some? [write-json write-html])
-                  (assoc-in [:nexus/effects :datastar.wow/send] (create-send write-json write-html))
-
-                  (some? write-json)
-                  (assoc-in [:nexus/effects :datastar.wow/send] (create-send write-json c/html))
-
-                  (some? write-html)
-                  (assoc-in [:nexus/effects :datastar.wow/send] (create-send json/write-json-str write-html))
-                  
-                  :finally update-nexus)
         dispatch-data (-> {:datastar.wow/response response :datastar.wow/request request}
                           (assoc :datastar.wow/with-open-sse? (response :datastar.wow/with-open-sse? with-open-sse?)))
         wp            (response :datastar.wow/write-profile write-profile)]
-    (if-some [connection (get-connection nex request dispatch-data)]
-      (do (nexus/dispatch nex {:sse connection :request request} dispatch-data actions)
+    (if-some [connection (get-connection dispatch request dispatch-data)]
+      (do (dispatch {:sse connection :request request} dispatch-data actions)
           {:status 204})
       (->sse-response
        request
        (cond-> {:d*.sse/on-close
                 (fn [& _]
-                  (nexus/dispatch nex {:sse nil :request request} dispatch-data [[:datastar.wow/sse-closed]]))
+                  (dispatch {:sse nil :request request} dispatch-data [[:datastar.wow/sse-closed]]))
                 :d*.sse/on-open
                 (fn [sse]
                   (let [system  {:sse sse :request request}]
                     (if (:datastar.wow/with-open-sse? dispatch-data)
                       (d*/with-open-sse sse
-                        (nexus/dispatch nex system dispatch-data actions))
-                      (nexus/dispatch nex system dispatch-data actions))))}
+                        (dispatch system dispatch-data actions))
+                      (dispatch system dispatch-data actions))))}
          (some? wp) (assoc :d*.sse/write-profile wp)
          (int? (:status response))  (assoc :status (:status response))
          (map? (:headers response)) (assoc :headers (:headers response)))))))
+
+(def fun-enhancers
+  "If we aren't having fun, then what is the point?"
+  {:🚀 :datastar.wow/fx})
 
 (defn- with-dispatch
   [opts ->sse-response]
@@ -176,16 +205,23 @@
 
 (defn with-datastar
   "Give your ring app The Power ™ 🚀"
-  [->sse-response {:datastar.wow/keys [html-attrs read-json with-open-sse? update-nexus write-json write-html write-profile]
-                   :or   {html-attrs     {}
-                          read-json      default-read-json
-                          update-nexus   identity
-                          with-open-sse? false}}]
+  [->sse-response {:datastar.wow/keys [html-attrs read-json with-open-sse? registries write-json write-html write-profile]
+                   :or {html-attrs     {}
+                        read-json      default-read-json
+                        registries     []
+                        with-open-sse? false}}]
   (let [html     (with-html (or write-html c/html) html-attrs)
         signals  (with-signals read-json)
-        dispatch (with-dispatch {:datastar.wow/with-open-sse? with-open-sse?
-                                 :datastar.wow/write-html     write-html
-                                 :datastar.wow/write-json     write-json
-                                 :datastar.wow/write-profile  write-profile
-                                 :datastar.wow/update-nexus   update-nexus} ->sse-response)]
-    (comp signals html dispatch)))
+        registry (create-registry
+                  (into [default-registry] registries)
+                  {:datastar.wow/write-html     write-html
+                   :datastar.wow/write-json     write-json})
+        dispatch  (fn [system dispatch-data fx]
+                    (nexus/dispatch registry system dispatch-data fx))]
+    (comp
+     signals
+     html
+     (with-dispatch
+       {:datastar.wow/with-open-sse? with-open-sse?
+        :datastar.wow/write-profile  write-profile
+        :datastar.wow/dispatch       dispatch} ->sse-response))))

--- a/src/datastar/wow/middleware.clj
+++ b/src/datastar/wow/middleware.clj
@@ -203,21 +203,32 @@
                                    h))))
           res)))))
 
+(defn create-dispatch
+  [{:datastar.wow/keys [registries write-json write-html]
+    :or {registries    []}}]
+  (let [registry (create-registry
+                  (into [default-registry] registries)
+                  {:datastar.wow/write-html write-html
+                   :datastar.wow/write-json write-json})]
+    (fn dispatch
+      ([dispatch-data fx]
+       (dispatch {:sse nil :request nil} dispatch-data fx))
+      ([system dispatch-data fx]
+       (nexus/dispatch registry system dispatch-data fx)))))
+
 (defn with-datastar
   "Give your ring app The Power ™ 🚀"
-  [->sse-response {:datastar.wow/keys [html-attrs read-json with-open-sse? registries write-json write-html write-profile]
+  [->sse-response {:datastar.wow/keys [html-attrs read-json with-open-sse? registries write-json write-html write-profile dispatch]
                    :or {html-attrs     {}
                         read-json      default-read-json
                         registries     []
                         with-open-sse? false}}]
   (let [html     (with-html (or write-html c/html) html-attrs)
         signals  (with-signals read-json)
-        registry (create-registry
-                  (into [default-registry] registries)
-                  {:datastar.wow/write-html     write-html
-                   :datastar.wow/write-json     write-json})
-        dispatch  (fn [system dispatch-data fx]
-                    (nexus/dispatch registry system dispatch-data fx))]
+        dispatch (or dispatch (create-dispatch
+                               {:datastar.wow/registries registries
+                                :datastar.wow/write-html write-html
+                                :datastar.wow/write-json write-json}))]
     (comp
      signals
      html

--- a/src/datastar/wow/schema.clj
+++ b/src/datastar/wow/schema.clj
@@ -145,6 +145,15 @@
 (def EffectRegistry
   [:or MapRegistry FunctionRegistry VectorRegistry])
 
+(def =>dispatch
+  [:function {:registry {::system [:map
+                                   [:sse :any]
+                                   [:request :any]]
+                         ::dispatch-data map?
+                         ::result :any}}
+   [:=> [:cat ::system ::dispatch-data [:vector DatastarAction]] [:sequential ::result]]
+   [:=> [:cat ::dispatch-data [:vector DatastarAction]] [:sequential ::result]]])
+
 (def WithDatastarOpts
   [:map
    [:datastar.wow/html-attrs {:optional true :description "A convenience for providing injected attributes to hiccup forms used in :body"} map?]
@@ -153,6 +162,7 @@
    [:datastar.wow/write-json {:optional true :description "A function meant to serialize Clojure types into json strings"} WriteJson]
    [:datastar.wow/write-profile {:optional true} WriteProfile]
    [:datastar.wow/registries {:optional true :description "A vector of effect registries"} [:vector EffectRegistry]]
+   [:datastar.wow/dispatch {:optional true :description "An existing dispatch function"} =>dispatch]
    [:datastar.wow/with-open-sse? {:optional true :description "If true, wrap dispatch in starfederation.datastar.clojure.api/with-open-sse?"} :boolean]])
 
 (def =>with-datastar

--- a/src/datastar/wow/schema.clj
+++ b/src/datastar/wow/schema.clj
@@ -91,10 +91,6 @@
     {:description "response level override for whether or not an sse connection closes automatically when finished" :optional true} :boolean]
    [:datastar.wow/connection {:description "An existing open sse connection. Useful for using a previously opened connection" :optional true} :some]])
 
-(def NexusUpdate
-  [:function {:registry {::nexus [:map-of :keyword :any]}}
-   [:=> [:cat ::nexus] ::nexus]])
-
 (def ReadJson
   [:=> [:cat :any] :any])
 
@@ -129,6 +125,26 @@
    [ac/write! fn?]
    [ac/content-encoding :string]])
 
+(def InterceptorPhase
+  [:enum [:before-dispatch :after-dispatch :before-effect :after-effect :before-action :after-action]])
+
+(def MapRegistry
+  [:map
+   [:datastar.wow/effects {:optional true} [:map-of :keyword fn?]]
+   [:datastar.wow/actions {:optional true} [:map-of :keyword fn?]]
+   [:datastar.wow/placeholders {:optional true} [:map-of :keyword fn?]]
+   [:datastar.wow/interceptors {:optional true} [:vector [:map-of InterceptorPhase fn?]]]])
+
+(def FunctionRegistry
+  [:=> :cat MapRegistry])
+
+(def VectorRegistry
+  [:cat [:function
+         [:=> [:cat :any [:* :any]] MapRegistry]] [:* :any]])
+
+(def EffectRegistry
+  [:or MapRegistry FunctionRegistry VectorRegistry])
+
 (def WithDatastarOpts
   [:map
    [:datastar.wow/html-attrs {:optional true :description "A convenience for providing injected attributes to hiccup forms used in :body"} map?]
@@ -136,7 +152,7 @@
    [:datastar.wow/read-json {:optional true :description "A function meant to deserialize signals into Clojure types"} ReadJson]
    [:datastar.wow/write-json {:optional true :description "A function meant to serialize Clojure types into json strings"} WriteJson]
    [:datastar.wow/write-profile {:optional true} WriteProfile]
-   [:datastar.wow/update-nexus {:optional true :description "An update function that supports extending the nexus governing effects"} NexusUpdate]
+   [:datastar.wow/registries {:optional true :description "A vector of effect registries"} [:vector EffectRegistry]]
    [:datastar.wow/with-open-sse? {:optional true :description "If true, wrap dispatch in starfederation.datastar.clojure.api/with-open-sse?"} :boolean]])
 
 (def =>with-datastar

--- a/test/src/datastar/wow_test.clj
+++ b/test/src/datastar/wow_test.clj
@@ -377,14 +377,31 @@
      (fn [m k v]
        (assoc m k (string/upper-case v))) {} signals)]])
 
+(defn connection-replacement
+  [{:keys [on-send connection]}]
+  {::d*/interceptors
+   [{:id ::connection-replacement
+     :before-effect
+     (fn [{:keys [effect system] :as ctx}]
+       (let [id (first effect)]
+         (cond
+           (= id :datastar.wow/connection)
+           (assoc-in ctx [:dispatch-data :datastar.wow/connection] connection)
+
+           (= id :datastar.wow/send)
+           (do
+             (on-send (:sse system))
+             ctx)
+
+           :else ctx)))}]})
+
 (deftest extending-nexus
   (testing "userland connection storage via interceptors"
     (let [request (-> (mock/request :post "/")
                       (mock/header "datastar-request" "true"))
           result  (handle request {::conn-id :fun-test-conn
                                    ::d*/fx   [[::d*/patch-signals {:ok true}]]}
-                          {::d*/update-nexus (fn [n]
-                                               (assoc n :nexus/interceptors [connection-storage-interceptor]))})
+                          {::d*/registries [{::d*/interceptors [connection-storage-interceptor]}]})
           {:d*.sse/keys [on-open]} (:opts result)
           sse-gen (test-generator)
           _ (on-open sse-gen)]
@@ -394,8 +411,8 @@
                       (mock/header "datastar-request" "true"))
           result  (handle request {::d*/fx  [[::d*/patch-signals {:ok true}]
                                              [::cowsay "Said the cow"]]}
-                          {::d*/update-nexus (fn [n]
-                                               (assoc-in n [:nexus/effects ::cowsay] cowsay))})
+                          {::d*/registries [{::d*/effects
+                                             {::cowsay cowsay}}]})
           {:d*.sse/keys [on-open]} (:opts result)
           result (on-open (test-generator))
           effect (->> result :results (filterv #(= "Moo! Said the cow" (:res %))) first)]
@@ -405,8 +422,8 @@
                       (mock/header "datastar-request" "true")
                       (mock/json-body {:name "turjan"}))
           result  (handle request {::d*/fx  [[::uc-signals]]}
-                          {::d*/update-nexus (fn [n]
-                                               (assoc-in n [:nexus/actions ::uc-signals] uc-signals))})
+                          {::d*/registries [{::d*/actions
+                                             {::uc-signals uc-signals}}]})
           {:d*.sse/keys [on-open]} (:opts result)
           result (on-open (test-generator))
           uc (-> result :results first :effect (nth 2) :name)]
@@ -416,9 +433,10 @@
                       (mock/header "datastar-request" "true"))
           result  (handle request {::d*/fx  [[::d*/patch-signals {:ok true}]
                                              [::badtimes "Error!"]]}
-                          {::d*/update-nexus (fn [n]
-                                               (-> (assoc-in n [:nexus/effects ::badtimes] badtimes)
-                                                   (assoc :nexus/interceptors [connection-storage-interceptor])))})
+                          {::d*/registries [(fn []
+                                              {::d*/effects
+                                               {::badtimes badtimes}
+                                               ::d*/interceptors [connection-storage-interceptor]})]})
           {:d*.sse/keys [on-open]} (:opts result)
           _ (on-open (test-generator))
           errors @*errors]
@@ -430,20 +448,7 @@
           request  (-> (mock/request :post "/")
                        (mock/header "datastar-request" "true"))
           result   (handle request {::d*/fx [[::d*/patch-signals {:ok true}]]}
-                           {::d*/update-nexus (fn [n]
-                                                (assoc n :nexus/interceptors [{:id ::connection-replacement
-                                                                               :before-effect
-                                                                               (fn [{:keys [effect system] :as ctx}]
-                                                                                 (let [id (first effect)]
-                                                                                   (cond
-                                                                                     (= id :datastar.wow/connection)
-                                                                                     (assoc-in ctx [:dispatch-data :datastar.wow/connection] test-gen)
-
-                                                                                     (= id :datastar.wow/send)
-                                                                                     (do
-                                                                                       (reset! *used-gen (:sse system))
-                                                                                       ctx)
-
-                                                                                     :else ctx)))}]))})] ;;; open with different sse-gen to show that the interceptor is used
+                           {::d*/registries [[connection-replacement {:on-send #(reset! *used-gen %)
+                                                                      :connection test-gen}]]})] ;;; open with different sse-gen to show that the interceptor is used
       (is (= @*used-gen test-gen))
       (is (= 204 (get-in result [:response :status] 204))))))

--- a/test/src/datastar/wow_test.clj
+++ b/test/src/datastar/wow_test.clj
@@ -403,7 +403,16 @@
 
            :else ctx)))}]})
 
-(deftest extending-nexus
+(deftest creating-dispatch
+  (let [dispatch (d*/dispatch {::d*/registries
+                               [{::d*/effects
+                                 {::cowsay cowsay}}]})
+        result  (dispatch {} [[::d*/patch-signals {:ok true}]
+                              [::cowsay "Said the cow"]])
+        effect (->> result :results (filterv #(= "Moo! Said the cow" (:res %))) first)]
+    (is (= "Moo! Said the cow" (:res effect)))))
+
+(deftest extending-dispatch
   (testing "userland connection storage via interceptors"
     (let [request (-> (mock/request :post "/")
                       (mock/header "datastar-request" "true"))
@@ -472,4 +481,16 @@
                            {::d*/registries [[connection-replacement {:on-send #(reset! *used-gen %)
                                                                       :connection test-gen}]]})] ;;; open with different sse-gen to show that the interceptor is used
       (is (= @*used-gen test-gen))
-      (is (= 204 (get-in result [:response :status] 204))))))
+      (is (= 204 (get-in result [:response :status] 204)))))
+  (testing "existing dispatch"
+    (let [dispatch (d*/dispatch {::d*/registries [{::d*/effects
+                                                   {::cowsay cowsay}}]})
+          request (-> (mock/request :post "/")
+                      (mock/header "datastar-request" "true"))
+          result  (handle request {::d*/fx  [[::d*/patch-signals {:ok true}]
+                                             [::cowsay "Said the cow"]]}
+                          {::d*/dispatch dispatch})
+          {:d*.sse/keys [on-open]} (:opts result)
+          result (on-open (test-generator))
+          effect (->> result :results (filterv #(= "Moo! Said the cow" (:res %))) first)]
+      (is (= "Moo! Said the cow" (:res effect))))))

--- a/test/src/datastar/wow_test.clj
+++ b/test/src/datastar/wow_test.clj
@@ -364,6 +364,14 @@
   [_ _ post-moo-text]
   (str "Moo! " post-moo-text))
 
+(defn moo-placeholder
+  [{:keys [post-moo]}]
+  post-moo)
+
+(defn async-cowsay
+  [{:keys [dispatch]} & _]
+  (dispatch [[::cowsay [:placeholder/moo]]] {:post-moo "Moo!"}))
+
 (defn badtimes
   "Throw an error for bad times"
   [_ _ msg]
@@ -428,6 +436,19 @@
           result (on-open (test-generator))
           uc (-> result :results first :effect (nth 2) :name)]
       (is (= uc "TURJAN"))))
+  (testing "placeholders"
+    (let [request (-> (mock/request :post "/")
+                      (mock/header "datastar-request" "true"))
+          result  (handle request {::d*/fx [[::async-cowsay]]}
+                          {::d*/registries [{::d*/placeholders
+                                             {:placeholder/moo moo-placeholder}
+                                             ::d*/effects
+                                             {::cowsay cowsay
+                                              ::async-cowsay async-cowsay}}]})
+          {:d*.sse/keys [on-open]} (:opts result)
+          result (on-open (test-generator))
+          effect (->> result :results first :res :results first)]
+      (is (= "Moo! Moo!" (:res effect)))))
   (testing "error capture"
     (let [request (-> (mock/request :post "/")
                       (mock/header "datastar-request" "true"))


### PR DESCRIPTION
It has been really enjoyable adding domain specific effects to datastar.wow apps. The `update-nexus` function serves the purpose well, but the `nexus` language (while accurate) feels like an odd detail. I am also noticing some patterns emerge in how I pass dependencies to effects and interceptors. I also have some dev tooling that would benefit from being able to dispatch from the REPL so this PR adds that ability as well.

### Breaking Changes

Removed `:datastar.wow/update-nexus` and replaced it with `:datastar.wow/registries`. `:datastar.wow/update-nexus` will now be ignored. Adds `dispatch`
function for creating a dispatch function for "out of band" dispatches.

### Changed

Effect + Nexus extension is now powered by registries. A registry IS a Nexus map, but with `:datastar.wow` namespaced keys. Keys are aliased
not to aura farm, but to reduce cognitive load (single require is a good thing).

```clojure
(def effect-map
  {::d*/effects
    {::myeffect
      (fn [ctx system arg1]
        (println arg1))}})

(defn effect-map-fn []
  {::d*/effects
    {::myeffect
      (fn [ctx system arg1]
        (println arg1))}})

(defn effect-map-fn-1
  [arg1]
  {::d*/effects
    {::othereffect
      (fn [ctx system]
        (println arg1))}})

;;; No more ::d*/update-nexus
(d*/with-datastar ->sse-response {::d*/registries [effect-map effect-map-fn [effect-map-fn-1 \"Mama mia!\"]]})
```

The vector syntax is particularly useful for scenarios using a component system like [integrant](https://github.com/weavejester/integrant).

``` clojure
(require '[integrant.core :as ig])

(def config
  {::datastar-config
    {::d*/registries [effect-map effect-fn [sql-effect (ig/ref ::database-fn)]]}})
```

### Added

Adds a `dispatch` function that takes a subset of `with-datstar` options: `::d*/registries`, `::d*/write-json`, and `::d*/write-html`. This
dispatch can be passed to `with-datastar`.

```clojure
(def my-dispatch (d*/dispatch {::d*/registries [my-app-effects]}))

(d*/with-datastar ->sse-response {::d*/dispatch my-dispatch})
```

If a dispatch function is given, `::d*/registries`, `::d*/write-json`, and `::d*/write-html` options given to `with-datastar` will be ignored.