### PR TITLE
chore: upgrade datastar sdk to rc11 and nexus to 2026.06.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.0.0-RC11-wow0] - 2026-07-07
+
+### Changed
+
+- Update Datastar Clojure SDK (and the brotli, http-kit, and ring adapters) to version 1.0.0-RC11
+- Update Nexus to 2026.06.4
+
 ## [1.0.0-RC4-wow0] - 2025-11-04
 
 ### Changed

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src"]
  :deps  {com.cnuernber/charred     {:mvn/version "1.037"}
-         dev.data-star.clojure/sdk {:mvn/version "1.0.0-RC4"}
+         dev.data-star.clojure/sdk {:mvn/version "1.0.0-RC11"}
          dev.onionpancakes/chassis {:mvn/version "1.0.365"}
-         no.cjohansen/nexus        {:mvn/version "2025.10.2"}}
+         no.cjohansen/nexus        {:mvn/version "2026.06.4"}}
  :aliases
  {:dev {:extra-paths ["dev/src"]
-        :extra-deps  {dev.data-star.clojure/brotli   {:mvn/version "1.0.0-RC4"}
-                      dev.data-star.clojure/http-kit {:mvn/version "1.0.0-RC4"}
-                      dev.data-star.clojure/ring     {:mvn/version "1.0.0-RC4"}
+        :extra-deps  {dev.data-star.clojure/brotli   {:mvn/version "1.0.0-RC11"}
+                      dev.data-star.clojure/http-kit {:mvn/version "1.0.0-RC11"}
+                      dev.data-star.clojure/ring     {:mvn/version "1.0.0-RC11"}
                       hiccup/hiccup                  {:mvn/version "2.0.0"}
                       integrant/integrant            {:mvn/version "0.13.1"}
                       io.github.tonsky/clj-reload    {:mvn/version "0.9.7"}
@@ -19,13 +19,13 @@
          :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts   ["-m" "cognitect.test-runner"]
          :exec-fn     cognitect.test-runner.api/test}
-  
+
   :slim {:deps
          {io.github.abogoyavlensky/slim {:mvn/version "LATEST"}
           slipset/deps-deploy {:mvn/version "0.2.2"}}
          :ns-default slim.lib
          :exec-args {:lib         com.github.brianium/datastar.wow
-                     :version     "1.0.0-RC4-wow0"
+                     :version     "1.0.0-RC11-wow0"
                      :url         "https://github.com/brianium/datastar.wow"
                      :description "Decalarative and data-oriented Datastar apps for Clojure"
                      :developer   "Brian Scaturro"}}}}


### PR DESCRIPTION
## Summary

Tracks the latest RC of the official [Datastar Clojure SDK](https://github.com/starfederation/datastar-clojure), now at **1.0.0-RC11**.

- `dev.data-star.clojure/sdk` `1.0.0-RC4` → `1.0.0-RC11`
- `brotli`, `http-kit`, and `ring` adapters → `1.0.0-RC11` (dev alias)
- `no.cjohansen/nexus` `2025.10.2` → `2026.06.4`
- Our own lib version `1.0.0-RC4-wow0` → `1.0.0-RC11-wow0`
- CHANGELOG entry added

No source changes were required — the SDK function renames (e.g. `merge-fragment!` → `patch-elements!`) predate RC4, so our code already uses the current API. The RC11 additions (e.g. `view-transition-selector`) are additive.

## Test plan

- [x] `clojure -X:dev:test` — 18 tests, 39 assertions, 0 failures, 0 errors
- [x] `demo.app` / `demo.config` namespaces compile (exercising the http-kit2/brotli/ring adapters and Nexus directly)
