### PR TITLE
feat: add element namespace options from the official sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [1.0.0-RC11-wow0] - 2026-07-07
 
+### Added
+
+- Element namespace support for parity with the official SDK ([#5](https://github.com/brianium/datastar.wow/issues/5)):
+  - Re-export the `element-ns` option constant and its `ns-html` / `ns-svg` / `ns-mathml` values
+  - Also re-export the RC11 `view-transition-selector` option constant
+  - Both `element-ns` and `view-transition-selector` are now accepted as options on the `::d*/patch-elements` and `::d*/patch-elements-seq` effects
+
 ### Changed
 
 - Update Datastar Clojure SDK (and the brotli, http-kit, and ring adapters) to version 1.0.0-RC11

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Patches one or more elements in the DOM. By default, Datastar morphs elements by
       [::d*/patch-elements [:h2#other "Hello"] {d*/patch-mode d*/pm-replace}]]} ;;; Datastar options supported
 ```
 
+All patch options from the official SDK are supported in the trailing options map, including `d*/element-ns` (for patching into a non-HTML namespace) and `d*/view-transition-selector`:
+
+``` clojure
+{:🚀 [[::d*/patch-elements [:circle#demo] {d*/element-ns d*/ns-svg}]]} ;;; ns-html (default), ns-svg, ns-mathml
+```
+
 ### `:datastar.wow/patch-elements-seq`
 
 Identical to `:datastar.wow/patch-elements` except it takes a sequence of elements to patch.

--- a/src/datastar/wow.clj
+++ b/src/datastar/wow.clj
@@ -36,7 +36,12 @@
   {::d*/fx [[::d*/patch-elements [:h1#demo \"Hello\"]]]
    ::d*/with-open-sse? true} ; close sse connection after sending events
   {:🚀 [[::d*/patch-elements [:h1#demo \"Hello\"] {::d*/patch-mode ::d*/pm-replace}]]} ; enhance fun with the rocket emoji alias
+  {::d*/fx [[::d*/patch-elements [:circle#demo] {::d*/element-ns ::d*/ns-svg}]]} ; patch elements into an svg/mathml namespace
   ```
+
+  Patch options such as `::d*/element-ns` (with values `::d*/ns-html`, `::d*/ns-svg`, or `::d*/ns-mathml`) and
+  `::d*/view-transition-selector` mirror the [official SDK](https://github.com/starfederation/datastar-clojure) and are
+  supported as the trailing options map on the `::d*/patch-elements` and `::d*/patch-elements-seq` effects.
 
   The `::registries` option is used to extend a datastar.wow app. Application specific effects, actions, placeholders, and interceptors can be added.
   See the [nexus](https://github.com/cjohansen/nexus) documentation for more information. A registry is an effect map, a zero arity function that returns an effect map
@@ -111,6 +116,8 @@
 (def-clone selector d*/selector)
 (def-clone patch-mode d*/patch-mode)
 (def-clone use-view-transition d*/use-view-transition)
+(def-clone view-transition-selector d*/view-transition-selector)
+(def-clone element-ns d*/element-ns)
 (def-clone only-if-missing d*/only-if-missing)
 (def-clone auto-remove d*/auto-remove)
 (def-clone attributes d*/attributes)
@@ -122,6 +129,12 @@
 (def-clone pm-before d*/pm-before)
 (def-clone pm-after d*/pm-after)
 (def-clone pm-replace d*/pm-replace)
+
+;;; Element namespaces (values for the element-ns option)
+
+(def-clone ns-html d*/ns-html)
+(def-clone ns-svg d*/ns-svg)
+(def-clone ns-mathml d*/ns-mathml)
 
 ;;; Action helpers
 

--- a/src/datastar/wow/schema.clj
+++ b/src/datastar/wow/schema.clj
@@ -40,7 +40,13 @@
      d*/pm-after
      d*/pm-remove
      d*/pm-replace]]
-   [d*/use-view-transition {:optional true} :boolean]])
+   [d*/use-view-transition {:optional true} :boolean]
+   [d*/view-transition-selector {:optional true} :string]
+   [d*/element-ns {:optional true}
+    [:enum
+     d*/ns-html
+     d*/ns-svg
+     d*/ns-mathml]]])
 
 (def PatchSignalsOptions
   [:map {:closed true}

--- a/test/src/datastar/wow_test.clj
+++ b/test/src/datastar/wow_test.clj
@@ -101,6 +101,15 @@
           {[{:keys [res]}] :results} (on-open (test-generator))]
       (is (= ["datastar-patch-elements"
               ["mode append" "elements <h1 id=\"test\">hello</h1>"]
+              #:d*.sse{:id false :retry-duration false}] res))))
+  (testing "with an element namespace"
+    (let [request  (-> (mock/request :post "/")
+                       (mock/header "datastar-request" "true"))
+          result    (handle request {::d*/fx [[::d*/patch-elements [:circle#c] {d*/element-ns d*/ns-svg}]]})
+          {:d*.sse/keys [on-open]} (:opts result)
+          {[{:keys [res]}] :results} (on-open (test-generator))]
+      (is (= ["datastar-patch-elements"
+              ["namespace svg" "elements <circle id=\"c\"></circle>"]
               #:d*.sse{:id false :retry-duration false}] res)))))
 
 (deftest patch-elements-seq-effect
@@ -124,6 +133,17 @@
               ["mode append"
                "elements <h1 id=\"a\">hello</h1>"
                "elements <h2 id=\"b\">goodbye</h2>"]
+              #:d*.sse{:id false :retry-duration false}] res))))
+  (testing "with an element namespace"
+    (let [request  (-> (mock/request :post "/")
+                       (mock/header "datastar-request" "true"))
+          result    (handle request {::d*/fx [[::d*/patch-elements-seq [[:circle#a] [:rect#b]] {d*/element-ns d*/ns-svg}]]})
+          {:d*.sse/keys [on-open]} (:opts result)
+          {[{:keys [res]}] :results} (on-open (test-generator))]
+      (is (= ["datastar-patch-elements"
+              ["namespace svg"
+               "elements <circle id=\"a\"></circle>"
+               "elements <rect id=\"b\"></rect>"]
               #:d*.sse{:id false :retry-duration false}] res)))))
 
 (deftest patch-signals-effect
@@ -288,7 +308,7 @@
   (testing "alternative write-html function"
     (let [request (mock/request :get "/")
           {:keys [response]} (handle request {:body [:h1 {:class "cool"} "hello"]} {::d*/html-attrs {:data-cool "very"}
-                                                                                     ::d*/write-html #(str (hiccup/html %))})]
+                                                                                    ::d*/write-html #(str (hiccup/html %))})]
       (is (= response {:status  200
                        :body    "<h1 class=\"cool\" data-cool=\"very\">hello</h1>"
                        :headers {"Content-Type" "text/html; charset=utf-8"}}))))


### PR DESCRIPTION
## Summary

Closes #5 — adds parity with the official SDK's element-namespace options.

The runtime already passed options opaquely through to the SDK's `patch-elements!`; the gaps were that the constants weren't re-exported and the **closed** `PatchElementsOptions` schema would have *rejected* the new keys.

- Re-export `element-ns` and its values `ns-html` / `ns-svg` / `ns-mathml` from `datastar.wow`
- Re-export the RC11 `view-transition-selector` option (a natural sibling the closed schema also rejected)
- Accept `element-ns` and `view-transition-selector` as options on the `::d*/patch-elements` and `::d*/patch-elements-seq` effects (added to `PatchElementsOptions`, which both effects share)
- Docstring + README examples, CHANGELOG entry (folded under the unreleased `1.0.0-RC11-wow0`)

```clojure
{:🚀 [[::d*/patch-elements [:circle#demo] {d*/element-ns d*/ns-svg}]]}
```

## Test plan

- [x] `clojure -X:dev:test` — 18 tests, 41 assertions, 0 failures, 0 errors (adds `element-ns` coverage to the `patch-elements` and `patch-elements-seq` effect tests)
- [x] Verified end-to-end at the REPL: the effect emits a `namespace svg` data line, and the schema validates `element-ns` / `view-transition-selector` while rejecting a bogus namespace value
